### PR TITLE
include asm-generic/ioctls.h

### DIFF
--- a/custom_termios2.c
+++ b/custom_termios2.c
@@ -5,6 +5,7 @@
  */
 #include "custom_termios2.h"
 #include <asm/ioctls.h>
+#include <asm-generic/ioctls.h>
 #include <errno.h>
 #include <sys/ioctl.h>
 


### PR DESCRIPTION
This helps in including definitions for TCGETS2 TCSETSW2 and TCSETSF2

Fixes

custom_termios2.c:14:19: error: use of undeclared identifier 'TCGETS2'                                                  return ioctl(fd, TCGETS2, termios);                                                                                              ^                                                                                      custom_termios2.c:24:9: error: use of undeclared identifier 'TCSETS2'                                                           cmd = TCSETS2;                                                                                                        ^                                                                                         custom_termios2.c:27:9: error: use of undeclared identifier 'TCSETSW2'                                                          cmd = TCSETSW2;                                                                                                       ^                                                                                         custom_termios2.c:30:9: error: use of undeclared identifier 'TCSETSF2'                                                          cmd = TCSETSF2;
                      ^

Signed-off-by: Khem Raj <raj.khem@gmail.com>